### PR TITLE
ZK proved perlin noise

### DIFF
--- a/circuits/perlin/CalculateTotal.circom
+++ b/circuits/perlin/CalculateTotal.circom
@@ -1,0 +1,16 @@
+pragma circom 2.0.3;
+
+template CalculateTotal(n) {
+    signal input in[n];
+    signal output out;
+
+    signal sums[n];
+
+    sums[0] <== in[0];
+
+    for (var i = 1; i < n; i++) {
+        sums[i] <== sums[i-1] + in[i];
+    }
+
+    out <== sums[n-1];
+}

--- a/circuits/perlin/CalculateTotal.circom
+++ b/circuits/perlin/CalculateTotal.circom
@@ -1,3 +1,10 @@
+/*
+ * Adapted from darkforest-v0.6's implementation of perlin noise. All
+ * credit is due to the Darkforest team for the original source.
+ * Original source: https://github.com/darkforest-eth/darkforest-v0.6. 
+ * Only change is import paths.
+ */
+
 pragma circom 2.0.3;
 
 template CalculateTotal(n) {

--- a/circuits/perlin/QuinSelector.circom
+++ b/circuits/perlin/QuinSelector.circom
@@ -1,0 +1,33 @@
+pragma circom 2.0.3;
+
+include "../node_modules/maci-circuits/node_modules/circomlib/circuits/comparators.circom";
+include "CalculateTotal.circom";
+
+template QuinSelector(choices) {
+    signal input in[choices];
+    signal input index;
+    signal output out;
+
+    // Ensure that index < choices
+    component lessThan = LessThan(4);
+    lessThan.in[0] <== index;
+    lessThan.in[1] <== choices;
+    lessThan.out === 1;
+
+    component calcTotal = CalculateTotal(choices);
+    component eqs[choices];
+
+    // For each item, check whether its index equals the input index.
+    for (var i = 0; i < choices; i ++) {
+        eqs[i] = IsEqual();
+        eqs[i].in[0] <== i;
+        eqs[i].in[1] <== index;
+
+        // eqs[i].out is 1 if the index matches. As such, at most one input to
+        // calcTotal is not 0.
+        calcTotal.in[i] <== eqs[i].out * in[i];
+    }
+
+    // Returns 0 + 0 + 0 + item
+    out <== calcTotal.out;
+}

--- a/circuits/perlin/QuinSelector.circom
+++ b/circuits/perlin/QuinSelector.circom
@@ -1,3 +1,10 @@
+/*
+ * Adapted from darkforest-v0.6's implementation of perlin noise. All
+ * credit is due to the Darkforest team for the original source.
+ * Original source: https://github.com/darkforest-eth/darkforest-v0.6. 
+ * Only change is import paths.
+ */
+
 pragma circom 2.0.3;
 
 include "../node_modules/maci-circuits/node_modules/circomlib/circuits/comparators.circom";

--- a/circuits/perlin/perlin.circom
+++ b/circuits/perlin/perlin.circom
@@ -1,0 +1,440 @@
+/*
+ * Adapted from darkforest-v0.6's implementation of perlin noise. All
+ * credit is due to the Darkforest team for the original source.
+ * Original source: https://github.com/darkforest-eth/darkforest-v0.6. 
+ * Only change is import paths.
+ */
+
+pragma circom 2.0.3;
+
+include "../node_modules/maci-circuits/node_modules/circomlib/circuits/mimcsponge.circom";
+include "../node_modules/maci-circuits/node_modules/circomlib/circuits/comparators.circom";
+include "../node_modules/maci-circuits/node_modules/circomlib/circuits/sign.circom";
+include "../node_modules/maci-circuits/node_modules/circomlib/circuits/bitify.circom";
+include "../range_proof/circuit.circom";
+include "QuinSelector.circom";
+
+// input: three field elements: x, y, scale (all absolute value < 2^32)
+// output: pseudorandom integer in [0, 15]
+template Random() {
+    signal input in[3];
+    signal input KEY;
+    signal output out;
+
+    component mimc = MiMCSponge(3, 4, 1);
+
+    mimc.ins[0] <== in[0];
+    mimc.ins[1] <== in[1];
+    mimc.ins[2] <== in[2];
+    mimc.k <== KEY;
+
+    component num2Bits = Num2Bits(254);
+    num2Bits.in <== mimc.outs[0];
+    out <== num2Bits.out[3] * 8 + num2Bits.out[2] * 4 + num2Bits.out[1] * 2 + num2Bits.out[0];
+}
+
+// input: any field elements
+// output: 1 if field element is in (p/2, p-1], 0 otherwise
+template IsNegative() {
+    signal input in;
+    signal output out;
+
+    component num2Bits = Num2Bits(254);
+    num2Bits.in <== in;
+    component sign = Sign();
+
+    for (var i = 0; i < 254; i++) {
+        sign.in[i] <== num2Bits.out[i];
+    }
+
+    out <== sign.sign;
+}
+
+// input: dividend and divisor field elements in [0, sqrt(p))
+// output: remainder and quotient field elements in [0, p-1] and [0, sqrt(p)
+// Haven't thought about negative divisor yet. Not needed.
+// -8 % 5 = 2. [-8 -> 8. 8 % 5 -> 3. 5 - 3 -> 2.]
+// (-8 - 2) // 5 = -2
+// -8 + 2 * 5 = 2
+// check: 2 - 2 * 5 = -8
+template Modulo(divisor_bits, SQRT_P) {
+    signal input dividend; // -8
+    signal input divisor; // 5
+    signal output remainder; // 2
+    signal output quotient; // -2
+
+    component is_neg = IsNegative();
+    is_neg.in <== dividend;
+
+    signal output is_dividend_negative;
+    is_dividend_negative <== is_neg.out;
+
+    signal output dividend_adjustment;
+    dividend_adjustment <== 1 + is_dividend_negative * -2; // 1 or -1
+
+    signal output abs_dividend;
+    abs_dividend <== dividend * dividend_adjustment; // 8
+
+    signal output raw_remainder;
+    raw_remainder <-- abs_dividend % divisor;
+
+    signal output neg_remainder;
+    neg_remainder <-- divisor - raw_remainder;
+
+    // 0xsage: https://github.com/0xSage/nightmarket/blob/fc4e5264436c75d37940fead3f47d650927a9120/circuits/list/Perlin.circom#L93-L108
+    component raw_rem_is_zero = IsZero();
+    raw_rem_is_zero.in <== raw_remainder;
+
+    signal raw_rem_not_zero;
+    raw_rem_not_zero <== 1 - raw_rem_is_zero.out;
+
+    signal iff;
+    iff <== is_dividend_negative * raw_rem_not_zero;
+
+    signal is_neg_remainder;
+    is_neg_remainder <== neg_remainder * iff;
+
+    signal elsef;
+    elsef <== 1 - iff;
+
+    remainder <== raw_remainder * elsef + is_neg_remainder;
+
+    quotient <-- (dividend - remainder) / divisor; // (-8 - 2) / 5 = -2.
+
+    dividend === divisor * quotient + remainder; // -8 = 5 * -2 + 2.
+
+    component rp = MultiRangeProof(3, 128);
+    rp.in[0] <== divisor;
+    rp.in[1] <== quotient;
+    rp.in[2] <== dividend;
+    rp.max_abs_value <== SQRT_P;
+
+    // check that 0 <= remainder < divisor
+    component remainderUpper = LessThan(divisor_bits);
+    remainderUpper.in[0] <== remainder;
+    remainderUpper.in[1] <== divisor;
+    remainderUpper.out === 1;
+}
+
+// input: three field elements x, y, scale (all absolute value < 2^32)
+// output: (NUMERATORS) a random unit vector in one of 16 directions
+template RandomGradientAt(DENOMINATOR) {
+    var vecs[16][2] = [[1000,0],[923,382],[707,707],[382,923],[0,1000],[-383,923],[-708,707],[-924,382],[-1000,0],[-924,-383],[-708,-708],[-383,-924],[-1,-1000],[382,-924],[707,-708],[923,-383]];
+
+    signal input in[2];
+    signal input scale;
+    signal input KEY;
+
+    signal output out[2];
+    component rand = Random();
+    rand.in[0] <== in[0];
+    rand.in[1] <== in[1];
+    rand.in[2] <== scale;
+    rand.KEY <== KEY;
+    component xSelector = QuinSelector(16);
+    component ySelector = QuinSelector(16);
+    for (var i = 0; i < 16; i++) {
+        xSelector.in[i] <== vecs[i][0];
+        ySelector.in[i] <== vecs[i][1];
+    }
+    xSelector.index <== rand.out;
+    ySelector.index <== rand.out;
+
+    signal vectorDenominator;
+    vectorDenominator <== DENOMINATOR / 1000;
+
+    out[0] <== xSelector.out * vectorDenominator;
+    out[1] <== ySelector.out * vectorDenominator;
+}
+
+// input: x, y, scale (field elements absolute value < 2^32)
+// output: 4 corners of a square with sidelen = scale (INTEGER coords)
+// and parallel array of 4 gradient vectors (NUMERATORS)
+template GetCornersAndGradVectors(scale_bits, DENOMINATOR, SQRT_P) {
+    signal input p[2];
+    signal input scale;
+    signal input KEY;
+
+    component xmodulo = Modulo(scale_bits, SQRT_P);
+    xmodulo.dividend <== p[0];
+    xmodulo.divisor <== scale;
+
+    component ymodulo = Modulo(scale_bits, SQRT_P);
+    ymodulo.dividend <== p[1];
+    ymodulo.divisor <== scale;
+
+    signal bottomLeftCoords[2];
+    bottomLeftCoords[0] <== p[0] - xmodulo.remainder;
+    bottomLeftCoords[1] <== p[1] - ymodulo.remainder;
+
+    signal bottomRightCoords[2];
+    bottomRightCoords[0] <== bottomLeftCoords[0] + scale;
+    bottomRightCoords[1] <== bottomLeftCoords[1];
+
+    signal topLeftCoords[2];
+    topLeftCoords[0] <== bottomLeftCoords[0];
+    topLeftCoords[1] <== bottomLeftCoords[1] + scale;
+
+    signal topRightCoords[2];
+    topRightCoords[0] <== bottomLeftCoords[0] + scale;
+    topRightCoords[1] <== bottomLeftCoords[1] + scale;
+
+    component bottomLeftRandGrad = RandomGradientAt(DENOMINATOR);
+    bottomLeftRandGrad.in[0] <== bottomLeftCoords[0];
+    bottomLeftRandGrad.in[1] <== bottomLeftCoords[1];
+    bottomLeftRandGrad.scale <== scale;
+    bottomLeftRandGrad.KEY <== KEY;
+    signal bottomLeftGrad[2];
+    bottomLeftGrad[0] <== bottomLeftRandGrad.out[0];
+    bottomLeftGrad[1] <== bottomLeftRandGrad.out[1];
+
+    component bottomRightRandGrad = RandomGradientAt(DENOMINATOR);
+    bottomRightRandGrad.in[0] <== bottomRightCoords[0];
+    bottomRightRandGrad.in[1] <== bottomRightCoords[1];
+    bottomRightRandGrad.scale <== scale;
+    bottomRightRandGrad.KEY <== KEY;
+    signal bottomRightGrad[2];
+    bottomRightGrad[0] <== bottomRightRandGrad.out[0];
+    bottomRightGrad[1] <== bottomRightRandGrad.out[1];
+
+    component topLeftRandGrad = RandomGradientAt(DENOMINATOR);
+    topLeftRandGrad.in[0] <== topLeftCoords[0];
+    topLeftRandGrad.in[1] <== topLeftCoords[1];
+    topLeftRandGrad.scale <== scale;
+    topLeftRandGrad.KEY <== KEY;
+    signal topLeftGrad[2];
+    topLeftGrad[0] <== topLeftRandGrad.out[0];
+    topLeftGrad[1] <== topLeftRandGrad.out[1];
+
+    component topRightRandGrad = RandomGradientAt(DENOMINATOR);
+    topRightRandGrad.in[0] <== topRightCoords[0];
+    topRightRandGrad.in[1] <== topRightCoords[1];
+    topRightRandGrad.scale <== scale;
+    topRightRandGrad.KEY <== KEY;
+    signal topRightGrad[2];
+    topRightGrad[0] <== topRightRandGrad.out[0];
+    topRightGrad[1] <== topRightRandGrad.out[1];
+
+    signal output grads[4][2];
+    signal output coords[4][2];
+
+    // INTS
+    coords[0][0] <== bottomLeftCoords[0];
+    coords[0][1] <== bottomLeftCoords[1];
+    coords[1][0] <== bottomRightCoords[0];
+    coords[1][1] <== bottomRightCoords[1];
+    coords[2][0] <== topLeftCoords[0];
+    coords[2][1] <== topLeftCoords[1];
+    coords[3][0] <== topRightCoords[0];
+    coords[3][1] <== topRightCoords[1];
+
+
+    // FRACTIONS
+    grads[0][0] <== bottomLeftGrad[0];
+    grads[0][1] <== bottomLeftGrad[1];
+    grads[1][0] <== bottomRightGrad[0];
+    grads[1][1] <== bottomRightGrad[1];
+    grads[2][0] <== topLeftGrad[0];
+    grads[2][1] <== topLeftGrad[1];
+    grads[3][0] <== topRightGrad[0];
+    grads[3][1] <== topRightGrad[1];
+}
+
+// @0xSage: consolidated template for Circom2 compatibility
+// https://github.com/0xSage/nightmarket/blob/fc4e5264436c75d37940fead3f47d650927a9120/circuits/list/Perlin.circom#L254-L283
+// In order: BL, BR, TL, TR
+// input: corner is FRAC NUMERATORS of scale x scale square, scaled down to unit square
+// p is FRAC NUMERATORS of a point inside a scale x scale that was scaled down to unit sqrt
+// output: FRAC NUMERATOR of weight of the gradient at this corner for this point
+template GetWeight(DENOMINATOR, WHICHCORNER) {
+    signal input corner[2];
+    signal input p[2];
+
+    signal diff[2];
+
+    if (WHICHCORNER == 0) {
+        diff[0] <== p[0] - corner[0];
+        diff[1] <== p[1] - corner[1];
+    } else if (WHICHCORNER == 1) {
+        diff[0] <== corner[0] - p[0];
+        diff[1] <== p[1] - corner[1];
+    } else if (WHICHCORNER == 2) {
+        diff[0] <== p[0] - corner[0];
+        diff[1] <== corner[1] - p[1];
+    } else {
+        diff[0] <== corner[0] - p[0];
+        diff[1] <== corner[1] - p[1];
+    }
+
+    signal factor[2];
+    factor[0] <== DENOMINATOR - diff[0];
+    factor[1] <== DENOMINATOR - diff[1];
+
+    signal nominator;
+    nominator <== factor[0] * factor[1];
+    signal output out;
+    out <-- nominator / DENOMINATOR;
+    nominator === out * DENOMINATOR;
+}
+
+// dot product of two vector NUMERATORS
+template Dot(DENOMINATOR) {
+    signal input a[2];
+    signal input b[2];
+    signal prod[2];
+    signal sum;
+    signal output out;
+
+    prod[0] <== a[0] * b[0];
+    prod[1] <== a[1] * b[1];
+
+    sum <== prod[0] + prod[1];
+    out <-- sum / DENOMINATOR;
+    sum === out * DENOMINATOR;
+}
+
+// input: 4 gradient unit vectors (NUMERATORS)
+// corner coords of a scale x scale square (ints)
+// point inside (int world coords)
+template PerlinValue(DENOMINATOR) {
+    signal input grads[4][2];
+    signal input coords[4][2];
+    signal input scale;
+    signal input p[2];
+
+    component getWeights[4];
+    getWeights[0] = GetWeight(DENOMINATOR, 0);
+    getWeights[1] = GetWeight(DENOMINATOR, 1);
+    getWeights[2] = GetWeight(DENOMINATOR, 2);
+    getWeights[3] = GetWeight(DENOMINATOR, 3);
+
+    signal distVec[4][2];
+    signal scaledDistVec[4][2];
+
+    component dots[4];
+
+    signal retNominator[4];
+    signal ret[4];
+    signal output out;
+
+    for (var i = 0; i < 4; i++) {
+        distVec[i][0] <== p[0] - coords[i][0];
+        distVec[i][1] <== p[1] - coords[i][1];
+
+        getWeights[i].corner[0] <-- coords[i][0] / scale;
+        coords[i][0] === getWeights[i].corner[0] * scale;
+
+        getWeights[i].corner[1] <-- coords[i][1] / scale;
+        coords[i][1] === getWeights[i].corner[1] * scale;
+
+        getWeights[i].p[0] <-- p[0] / scale;
+        p[0] === getWeights[i].p[0] * scale;
+
+        getWeights[i].p[1] <-- p[1] / scale;
+        p[1] === getWeights[i].p[1] * scale;
+
+        scaledDistVec[i][0] <-- distVec[i][0] / scale;
+        distVec[i][0] === scaledDistVec[i][0] * scale;
+
+        scaledDistVec[i][1] <-- distVec[i][1] / scale;
+        distVec[i][1] === scaledDistVec[i][1] * scale;
+
+        // can be made more efficient.
+
+        dots[i] = Dot(DENOMINATOR);
+        dots[i].a[0] <== grads[i][0];
+        dots[i].a[1] <== grads[i][1];
+        dots[i].b[0] <== scaledDistVec[i][0];
+        dots[i].b[1] <== scaledDistVec[i][1];
+
+        retNominator[i] <== dots[i].out * getWeights[i].out;
+        ret[i] <-- retNominator[i] / DENOMINATOR;
+        retNominator[i] === DENOMINATOR * ret[i];
+    }
+
+    out <== ret[0] + ret[1] + ret[2] + ret[3];
+}
+
+template SingleScalePerlin(scale_bits, DENOMINATOR, SQRT_P) {
+    signal input p[2];
+    signal input KEY;
+    signal input SCALE;
+    signal output out;
+    component cornersAndGrads = GetCornersAndGradVectors(scale_bits, DENOMINATOR, SQRT_P);
+    component perlinValue = PerlinValue(DENOMINATOR);
+    cornersAndGrads.scale <== SCALE;
+    cornersAndGrads.p[0] <== p[0];
+    cornersAndGrads.p[1] <== p[1];
+    cornersAndGrads.KEY <== KEY;
+    perlinValue.scale <== SCALE;
+    perlinValue.p[0] <== DENOMINATOR * p[0];
+    perlinValue.p[1] <== DENOMINATOR * p[1];
+
+    for (var i = 0; i < 4; i++) {
+        perlinValue.coords[i][0] <== DENOMINATOR * cornersAndGrads.coords[i][0];
+        perlinValue.coords[i][1] <== DENOMINATOR * cornersAndGrads.coords[i][1];
+        perlinValue.grads[i][0] <== cornersAndGrads.grads[i][0];
+        perlinValue.grads[i][1] <== cornersAndGrads.grads[i][1];
+    }
+
+    out <== perlinValue.out;
+}
+
+template MultiScalePerlin() {
+    var DENOMINATOR = 1125899906842624000; // good for length scales up to 16384. 2^50 * 1000
+    var DENOMINATOR_BITS = 61;
+    var SQRT_P = 1000000000000000000000000000000000000;
+
+    signal input p[2];
+    signal input KEY;
+    signal input SCALE; // power of 2 at most 16384 so that DENOMINATOR works
+    signal input xMirror; // 1 is true, 0 is false
+    signal input yMirror; // 1 is true, 0 is false
+    signal output out;
+    component perlins[3];
+
+    xMirror * (xMirror - 1) === 0;
+    yMirror * (yMirror - 1) === 0;
+
+    component rp = MultiRangeProof(2, 35);
+    rp.in[0] <== p[0];
+    rp.in[1] <== p[1];
+    rp.max_abs_value <== 2 ** 31;
+
+    component xIsNegative = IsNegative();
+    component yIsNegative = IsNegative();
+    xIsNegative.in <== p[0];
+    yIsNegative.in <== p[1];
+
+    // Make scale_bits a few bits bigger so we have a buffer
+    perlins[0] = SingleScalePerlin(16, DENOMINATOR, SQRT_P);
+    perlins[1] = SingleScalePerlin(16, DENOMINATOR, SQRT_P);
+    perlins[2] = SingleScalePerlin(16, DENOMINATOR, SQRT_P);
+
+    // add perlins[0], perlins[1], perlins[2], and perlins[0] (again)
+    component adder = CalculateTotal(4);
+    signal xSignShouldFlip[3];
+    signal ySignShouldFlip[3];
+    for (var i = 0; i < 3; i++) {
+        xSignShouldFlip[i] <== xIsNegative.out * yMirror; // should flip sign of x coord (p[0]) if yMirror is true (i.e. flip along vertical axis) and p[0] is negative
+        ySignShouldFlip[i] <== yIsNegative.out * xMirror; // should flip sign of y coord (p[1]) if xMirror is true (i.e. flip along horizontal axis) and p[1] is negative
+        perlins[i].p[0] <== p[0] * (-2 * xSignShouldFlip[i] + 1);
+        perlins[i].p[1] <== p[1] * (-2 * ySignShouldFlip[i] + 1);
+        perlins[i].KEY <== KEY;
+        perlins[i].SCALE <== SCALE * 2 ** i;
+        adder.in[i] <== perlins[i].out;
+    }
+    adder.in[3] <== perlins[0].out;
+
+    signal outDividedByCount;
+    outDividedByCount <-- adder.out / 4;
+    adder.out === 4 * outDividedByCount;
+
+    // outDividedByCount is between [-DENOMINATOR*sqrt(2)/2, DENOMINATOR*sqrt(2)/2]
+    component divBy16 = Modulo(DENOMINATOR_BITS, SQRT_P);
+    divBy16.dividend <== outDividedByCount * 16;
+    divBy16.divisor <== DENOMINATOR;
+    out <== divBy16.quotient + 16;
+}
+
+// component main = MultiScalePerlin(3); // if you change this n, you also need to recompute DENOMINATOR with JS.

--- a/circuits/range_proof/circuit.circom
+++ b/circuits/range_proof/circuit.circom
@@ -1,0 +1,63 @@
+/*
+ * Adapted from darkforest-v0.6's implementation of range_proof. All
+ * credit is due to the Darkforest team for the original source.
+ * Original source: https://github.com/darkforest-eth/darkforest-v0.6. 
+ * Only change is import paths.
+ */
+
+pragma circom 2.0.3;
+
+include "../node_modules/maci-circuits/node_modules/circomlib/circuits/comparators.circom";
+include "../node_modules/maci-circuits/node_modules/circomlib/circuits/bitify.circom";
+
+// NB: RangeProof is inclusive.
+// input: field element, whose abs is claimed to be <= than max_abs_value
+// output: none
+// also checks that both max and abs(in) are expressible in `bits` bits
+template RangeProof(bits) {
+    signal input in;
+    signal input max_abs_value;
+
+    /* check that both max and abs(in) are expressible in `bits` bits  */
+    component n2b1 = Num2Bits(bits+1);
+    n2b1.in <== in + (1 << bits);
+    component n2b2 = Num2Bits(bits);
+    n2b2.in <== max_abs_value;
+
+    /* check that in + max is between 0 and 2*max */
+    component lowerBound = LessThan(bits+1);
+    component upperBound = LessThan(bits+1);
+
+    lowerBound.in[0] <== max_abs_value + in;
+    lowerBound.in[1] <== 0;
+    lowerBound.out === 0;
+
+    upperBound.in[0] <== 2 * max_abs_value;
+    upperBound.in[1] <== max_abs_value + in;
+    upperBound.out === 0;
+}
+
+// input: n field elements, whose abs are claimed to be less than max_abs_value
+// output: none
+template MultiRangeProof(n, bits) {
+    signal input in[n];
+    signal input max_abs_value;
+    component rangeProofs[n];
+
+    for (var i = 0; i < n; i++) {
+        rangeProofs[i] = RangeProof(bits);
+        rangeProofs[i].in <== in[i];
+        rangeProofs[i].max_abs_value <== max_abs_value;
+    }
+}
+
+/*
+template RPTester() {
+    signal input a;
+    component rp = RangeProof(10);
+    rp.in <== a;
+    rp.max_abs_value <== 100;
+}
+
+component main = RPTester();
+*/

--- a/circuits/test/move.test.ts
+++ b/circuits/test/move.test.ts
@@ -67,8 +67,8 @@ describe("Unit tests for CheckLeaves()", () => {
     it("fails if player tries to move troops they don't own", async () => {
         const p1 = new Player("A", BigInt("0xfff"));
         const p2 = new Player("B", BigInt("0xddd"));
-        const t1 = Tile.genOwned(p1, { r: 0, c: 0 }, 9, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(p1, { r: 0, c: 0 }, 9, 2, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(p1, { r: 0, c: 0 }, 9, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(p1, { r: 0, c: 0 }, 9, 2, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -88,8 +88,8 @@ describe("Unit tests for CheckLeaves()", () => {
     it("fails if proposed hashes don't match the new", async () => {
         const p1 = new Player("A", BigInt("0xfff"));
         const p2 = new Player("B", BigInt("0xddd"));
-        const t1 = Tile.genOwned(p1, { r: 0, c: 0 }, 9, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(p2, { r: 0, c: 0 }, 9, 2, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(p1, { r: 0, c: 0 }, 9, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(p2, { r: 0, c: 0 }, 9, 2, 0, 0, Tile.BARE_TILE);
 
         const w1 = await circuit.calculateWitness(
             {
@@ -123,8 +123,8 @@ describe("Unit tests for CheckLeaves()", () => {
     it("passes if move initiated by owner & new hashes valid", async () => {
         const p1 = new Player("A", BigInt("0xfff"));
         const p2 = new Player("B", BigInt("0xddd"));
-        const t1 = Tile.genOwned(p1, { r: 0, c: 0 }, 9, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(p2, { r: 0, c: 0 }, 9, 2, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(p1, { r: 0, c: 0 }, 9, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(p2, { r: 0, c: 0 }, 9, 2, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -266,7 +266,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genUnowned({ r: 124, c: 321 });
         const u1 = Tile.genOwned(
@@ -276,7 +276,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genOwned(
             p,
@@ -285,7 +285,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         const w = await circuit.calculateWitness(
@@ -315,7 +315,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genUnowned({ r: 124, c: 321 });
         const u1 = Tile.genOwned(
@@ -325,7 +325,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genOwned(
             p,
@@ -334,7 +334,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         const w = await circuit.calculateWitness(
@@ -365,7 +365,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genOwned(
             p2,
@@ -374,7 +374,7 @@ describe("Unit tests for CheckRsrc()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u1 = Tile.genOwned(
             p1,
@@ -383,7 +383,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genOwned(
             p1,
@@ -392,7 +392,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         const w = await circuit.calculateWitness(
@@ -423,7 +423,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genOwned(
             p2,
@@ -432,7 +432,7 @@ describe("Unit tests for CheckRsrc()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u1 = Tile.genOwned(
             p1,
@@ -441,7 +441,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genOwned(
             p1,
@@ -450,7 +450,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         const w = await circuit.calculateWitness(
@@ -480,7 +480,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genUnowned({ r: 124, c: 321 });
         const u1 = Tile.genOwned(
@@ -490,7 +490,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genUnowned({ r: 124, c: 321 });
 
@@ -522,7 +522,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genOwned(
             p2,
@@ -531,7 +531,7 @@ describe("Unit tests for CheckRsrc()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u1 = Tile.genOwned(
             p1,
@@ -540,7 +540,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genOwned(
             p2,
@@ -549,7 +549,7 @@ describe("Unit tests for CheckRsrc()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         const w = await circuit.calculateWitness(
@@ -579,7 +579,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genUnowned({ r: 124, c: 321 });
         const u1 = Tile.genOwned(
@@ -589,7 +589,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genOwned(
             p,
@@ -598,7 +598,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         const w = await circuit.calculateWitness(
@@ -629,7 +629,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genOwned(
             p2,
@@ -638,7 +638,7 @@ describe("Unit tests for CheckRsrc()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u1 = Tile.genOwned(
             p1,
@@ -647,7 +647,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genOwned(
             p2,
@@ -656,7 +656,7 @@ describe("Unit tests for CheckRsrc()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         const w = await circuit.calculateWitness(
@@ -687,7 +687,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genOwned(
             p2,
@@ -696,7 +696,7 @@ describe("Unit tests for CheckRsrc()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u1 = Tile.genOwned(
             p1,
@@ -705,7 +705,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const u2 = Tile.genOwned(
             p1,
@@ -714,7 +714,7 @@ describe("Unit tests for CheckRsrc()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         const w = await circuit.calculateWitness(
@@ -881,8 +881,8 @@ describe("Unit tests for CheckWaterUpdates()", () => {
     });
 
     it("fails if player loses troops on a non-water tile", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 1, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 1, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1017,8 +1017,8 @@ describe("Unit tests for CheckWaterUpdates()", () => {
     });
 
     it("passes if player keeps troops on a non-water tile", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 1, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 1, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1042,8 +1042,8 @@ describe("Unit tests for CheckRsrcCases()", () => {
     });
 
     it("fails (case 1)", async () => {
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 20, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 20, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1061,8 +1061,8 @@ describe("Unit tests for CheckRsrcCases()", () => {
     });
 
     it("fails (case 2)", async () => {
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1080,8 +1080,8 @@ describe("Unit tests for CheckRsrcCases()", () => {
     });
 
     it("fails (case 3, onto less resources)", async () => {
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1099,8 +1099,8 @@ describe("Unit tests for CheckRsrcCases()", () => {
     });
 
     it("fails (case 3, onto more or equal resources)", async () => {
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 1, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 1, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1118,8 +1118,8 @@ describe("Unit tests for CheckRsrcCases()", () => {
     });
 
     it("passes (case 1)", async () => {
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1137,8 +1137,8 @@ describe("Unit tests for CheckRsrcCases()", () => {
     });
 
     it("passes (case 2)", async () => {
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 15, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 15, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1156,8 +1156,8 @@ describe("Unit tests for CheckRsrcCases()", () => {
     });
 
     it("passes (case 3, onto less resources)", async () => {
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1175,8 +1175,8 @@ describe("Unit tests for CheckRsrcCases()", () => {
     });
 
     it("passes (case 3, onto more or equal resources)", async () => {
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 25, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 5, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 25, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1202,10 +1202,10 @@ describe("Unit tests for CheckCityIdCases()", () => {
     });
 
     it("fails if 'from' tile's city changes", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 0, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 0, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 0, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness({
             tFrom: t1.toCircuitInput(),
@@ -1221,9 +1221,9 @@ describe("Unit tests for CheckCityIdCases()", () => {
     });
 
     it("fails if city ID changes when moving onto enemy city", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
         const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.CITY_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
         const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.CITY_TILE);
 
         const w = await circuit.calculateWitness({
@@ -1240,9 +1240,9 @@ describe("Unit tests for CheckCityIdCases()", () => {
     });
 
     it("fails if city ID changes when moving onto enemy capital", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
         const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.CAPITAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
         const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.CAPITAL_TILE);
 
         const w = await circuit.calculateWitness({
@@ -1259,10 +1259,10 @@ describe("Unit tests for CheckCityIdCases()", () => {
     });
 
     it("fails if city ID changes when moving into a different city", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness({
             tFrom: t1.toCircuitInput(),
@@ -1278,10 +1278,10 @@ describe("Unit tests for CheckCityIdCases()", () => {
     });
 
     it("fails if city ID changes when moving in the same city", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness({
             tFrom: t1.toCircuitInput(),
@@ -1297,10 +1297,10 @@ describe("Unit tests for CheckCityIdCases()", () => {
     });
 
     it("fails if city ID changes when failing to take an enemy", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness({
             tFrom: t1.toCircuitInput(),
@@ -1316,10 +1316,10 @@ describe("Unit tests for CheckCityIdCases()", () => {
     });
 
     it("fails if city ID stays the same taking unowned", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 0, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 0, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 0, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness({
             tFrom: t1.toCircuitInput(),
@@ -1335,10 +1335,10 @@ describe("Unit tests for CheckCityIdCases()", () => {
     });
 
     it("fails if city ID stays the same taking enemy non-city", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 1, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 0, 2, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness({
             tFrom: t1.toCircuitInput(),
@@ -1362,10 +1362,10 @@ describe("Unit tests for CheckTypeConsistency()", () => {
     });
 
     it("fails if 'from' tile changes type", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.BARE_TILE);
         const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.WATER_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1383,9 +1383,9 @@ describe("Unit tests for CheckTypeConsistency()", () => {
     });
 
     it("fails if 'to' tile changes type, not an enemy capital", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
         const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.WATER_TILE);
 
         const w = await circuit.calculateWitness(
@@ -1404,7 +1404,7 @@ describe("Unit tests for CheckTypeConsistency()", () => {
     });
 
     it("fails if enemy capital is not turned into a city", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
         const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.CAPITAL_TILE);
         const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.WATER_TILE);
         const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.CAPITAL_TILE);
@@ -1425,7 +1425,7 @@ describe("Unit tests for CheckTypeConsistency()", () => {
     });
 
     it("fails if player capital turns into a city", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
         const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.CAPITAL_TILE);
         const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.WATER_TILE);
         const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.CITY_TILE);
@@ -1446,10 +1446,10 @@ describe("Unit tests for CheckTypeConsistency()", () => {
     });
 
     it("passes when moving onto a normal tile", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
-        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
+        const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.BARE_TILE);
 
         const w = await circuit.calculateWitness(
             {
@@ -1467,9 +1467,9 @@ describe("Unit tests for CheckTypeConsistency()", () => {
     });
 
     it("passes when taking over enemy capital", async () => {
-        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const t1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
         const t2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.CAPITAL_TILE);
-        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.NORMAL_TILE);
+        const u1 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 0 }, 10, 0, 0, 0, Tile.BARE_TILE);
         const u2 = Tile.genOwned(Tile.UNOWNED, { r: 0, c: 1 }, 10, 0, 0, 0, Tile.CITY_TILE);
 
         const w = await circuit.calculateWitness(
@@ -1507,7 +1507,7 @@ describe("Unit tests for CheckMerkleInclusion()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genOwned(
             p2,
@@ -1516,7 +1516,7 @@ describe("Unit tests for CheckMerkleInclusion()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         tree.insert(Utils.hIntoBigNumber(t1.hash()));
@@ -1552,7 +1552,7 @@ describe("Unit tests for CheckMerkleInclusion()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genOwned(
             p2,
@@ -1561,7 +1561,7 @@ describe("Unit tests for CheckMerkleInclusion()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         tree.insert(Utils.hIntoBigNumber(t1.hash()));
@@ -1597,7 +1597,7 @@ describe("Unit tests for CheckMerkleInclusion()", () => {
             1,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
         const t2 = Tile.genOwned(
             p2,
@@ -1606,7 +1606,7 @@ describe("Unit tests for CheckMerkleInclusion()", () => {
             2,
             0,
             0,
-            Tile.NORMAL_TILE
+            Tile.BARE_TILE
         );
 
         tree.insert(Utils.hIntoBigNumber(t1.hash()));

--- a/circuits/virtual/virtual.func.circom
+++ b/circuits/virtual/virtual.func.circom
@@ -7,7 +7,7 @@ include "../perlin/perlin.circom";
 
 template CheckVirtType(N_TL_ATRS, ROW_IDX, COL_IDX, TYPE_IDX, PERLIN_KEY, 
     PERLIN_SCALE, PERLIN_SYS_BITS, PERLIN_THRESHOLD_HILL, 
-    PERLIN_THRESHOLD_WATER, NORMAL_TYPE, WATER_TYPE, HILL_TYPE) {
+    PERLIN_THRESHOLD_WATER, BARE_TYPE, WATER_TYPE, HILL_TYPE) {
 
     signal input virt[N_TL_ATRS];
 
@@ -17,7 +17,7 @@ template CheckVirtType(N_TL_ATRS, ROW_IDX, COL_IDX, TYPE_IDX, PERLIN_KEY,
     signal perlin <== MultiScalePerlin()(
         [virt[ROW_IDX], virt[COL_IDX]], PERLIN_KEY, PERLIN_SCALE, 0, 0);
 
-    signal isNormal <== IsEqual()([virt[TYPE_IDX], NORMAL_TYPE]);
+    signal isBare <== IsEqual()([virt[TYPE_IDX], BARE_TYPE]);
     signal isWater <== IsEqual()([virt[TYPE_IDX], WATER_TYPE]);
     signal isHill <== IsEqual()([virt[TYPE_IDX], HILL_TYPE]);
 
@@ -26,7 +26,7 @@ template CheckVirtType(N_TL_ATRS, ROW_IDX, COL_IDX, TYPE_IDX, PERLIN_KEY,
     signal geqWaterThreshold <== GreaterEqThan(PERLIN_SYS_BITS)([perlin, 
         PERLIN_THRESHOLD_WATER]);
 
-    out <== Mux2()([isNormal, isWater, isHill, isHill], [geqWaterThreshold, 
+    out <== Mux2()([isBare, isWater, isHill, isHill], [geqWaterThreshold, 
         geqHillThreshold]);
 }
 
@@ -55,7 +55,7 @@ template Virtual() {
     var PERLIN_THRESHOLD_WATER = 17;
 
     // Id's used to check tile type
-    var NORMAL_TYPE = 0;
+    var BARE_TYPE = 0;
     var CITY_TYPE = 1;
     var WATER_TYPE = 2;
     var HILL_TYPE = 3;
@@ -80,7 +80,7 @@ template Virtual() {
 
     signal virtTypeCorrect <== CheckVirtType(N_TL_ATRS, ROW_IDX, COL_IDX,
         TYPE_IDX, PERLIN_KEY, PERLIN_SCALE, PERLIN_SYS_BITS, 
-        PERLIN_THRESHOLD_HILL, PERLIN_THRESHOLD_WATER, NORMAL_TYPE, WATER_TYPE, 
+        PERLIN_THRESHOLD_HILL, PERLIN_THRESHOLD_WATER, BARE_TYPE, WATER_TYPE, 
         HILL_TYPE)(virt);
     virtTypeCorrect === 1;
 }

--- a/circuits/virtual/virtual.func.circom
+++ b/circuits/virtual/virtual.func.circom
@@ -1,6 +1,22 @@
 pragma circom 2.1.1;
 
 include "../node_modules/maci-circuits/node_modules/circomlib/circuits/poseidon.circom";
+include "../perlin/perlin.circom";
+
+template CheckVirtType(N_TL_ATRS, ROW_IDX, COL_IDX, TYPE_IDX, PERLIN_KEY, 
+    PERLIN_SCALE) {
+
+    signal input virt[N_TL_ATRS];
+
+    signal output out;
+
+    // Perlin noise at location (r, c)
+    signal perlin <== MultiScalePerlin()(
+        [virt[ROW_IDX], virt[COL_IDX]], PERLIN_KEY, PERLIN_SCALE, 0, 0);
+    log(perlin);
+
+    out <== 1;
+}
 
 /*
  * Asserts that a virtual tile is computed faithfully with respect to committed
@@ -13,6 +29,11 @@ template Virtual() {
     var ROW_IDX = 0;
     var COL_IDX = 1;
     var KEY_IDX = 3;
+    var TYPE_IDX = 6;
+
+    // darkforest-v0.6 constants for MultiScalePerlin()
+    var PERLIN_KEY = 2;
+    var PERLIN_SCALE = 2;
 
     signal input hRand;
     signal input hVirt;
@@ -31,4 +52,8 @@ template Virtual() {
     signal circuitKey <== Poseidon(3)([rand, virt[ROW_IDX], virt[COL_IDX]]);
     signal keyCorrect <== IsEqual()([circuitKey, virt[KEY_IDX]]);
     keyCorrect === 1;
+
+    signal virtTypeCorrect <== CheckVirtType(N_TL_ATRS, ROW_IDX, COL_IDX,
+        TYPE_IDX, PERLIN_KEY, PERLIN_SCALE)(virt);
+    virtTypeCorrect === 1;
 }

--- a/circuits/virtual/virtual.func.circom
+++ b/circuits/virtual/virtual.func.circom
@@ -13,7 +13,6 @@ template CheckVirtType(N_TL_ATRS, ROW_IDX, COL_IDX, TYPE_IDX, PERLIN_KEY,
     // Perlin noise at location (r, c)
     signal perlin <== MultiScalePerlin()(
         [virt[ROW_IDX], virt[COL_IDX]], PERLIN_KEY, PERLIN_SCALE, 0, 0);
-    log(perlin);
 
     out <== 1;
 }

--- a/client/client.ts
+++ b/client/client.ts
@@ -97,7 +97,7 @@ async function commitToSpawn() {
     PLAYER.sampleBlind();
 
     // Save block number player commited to spawning
-    await PLAYER.commitToSpawn(PLAYER_SPAWN, nStates);
+    // await PLAYER.commitToSpawn(PLAYER_SPAWN, nStates);
 
     console.log("Getting spawn sig from enclave");
 

--- a/client/client.ts
+++ b/client/client.ts
@@ -10,6 +10,7 @@ import { Board } from "../game/Board.js";
 import { Utils, Groth16ProofCalldata, Groth16Proof } from "../game/Utils.js";
 import worlds from "../contracts/worlds.json" assert { type: "json" };
 import IWorldAbi from "../contracts/out/IWorld.sol/IWorld.json" assert { type: "json" };
+import { TerrainUtils } from "../game";
 
 /*
  * Conditions depend on which player is currently active.
@@ -55,6 +56,11 @@ const PLAYER = new Player(PLAYER_SYMBOL, signer.address);
  * Client's local belief on game state stored in Board object.
  */
 let b: Board;
+
+/*
+ * Cache for terrain
+ */
+const terrainUtils = new TerrainUtils();
 
 /*
  * Whether player has been spawned in.
@@ -263,7 +269,7 @@ async function errorResponse(msg: string) {
 socket.on("connect", async () => {
     console.log("Server connection established");
 
-    b = new Board();
+    b = new Board(terrainUtils);
 
     // Pass in dummy function to terrain generator because init is false
     await b.seed();

--- a/client/client.ts
+++ b/client/client.ts
@@ -1,5 +1,5 @@
 import readline from "readline";
-import { BigNumber, ethers, Signature } from "ethers";
+import { ethers } from "ethers";
 import { io, Socket } from "socket.io-client";
 import dotenv from "dotenv";
 dotenv.config({ path: "../.env" });
@@ -19,21 +19,16 @@ const PLAYER_PRIVKEY = JSON.parse(<string>process.env.ETH_PRIVKEYS)[
     PLAYER_SYMBOL
 ];
 const PLAYER_SPAWN: Location = {
-    r: BigInt(process.argv[3]),
-    c: BigInt(process.argv[4]),
+    r: Number(process.argv[3]),
+    c: Number(process.argv[4]),
 };
 
-/*
- * Misc client parameters.
- */
-const BOARD_SIZE: number = parseInt(<string>process.env.BOARD_SIZE, 10);
 const MOVE_PROMPT: string = "Next move: ";
-
-const MOVE_KEYS: Record<string, bigint[]> = {
-    w: [BigInt(-1), BigInt(0)],
-    a: [BigInt(0), BigInt(-1)],
-    s: [BigInt(1), BigInt(0)],
-    d: [BigInt(0), BigInt(1)],
+const MOVE_KEYS: Record<string, number[]> = {
+    w: [-1, 0],
+    a: [0, -1],
+    s: [1, 0],
+    d: [0, 1],
 };
 
 /*

--- a/contracts/src/libraries/LibSpawn.sol
+++ b/contracts/src/libraries/LibSpawn.sol
@@ -12,7 +12,7 @@ library LibSpawn {
         SpawnInputs memory spawnInputs,
         Signature memory sig
     ) internal view {
-        require(SpawnCommitment.get(player) != 0, "Commit to spawn first");
+        // require(SpawnCommitment.get(player) != 0, "Commit to spawn first");
         require(spawnInputs.spawnCityId != 0, "City ID must be non-zero");
         require(
             CityPlayer.getValue(spawnInputs.spawnCityId) == address(0),
@@ -23,10 +23,10 @@ library LibSpawn {
                 Config.getEnclave(),
             "Enclave spawn sig incorrect"
         );
-        require(
-            SpawnCommitment.get(player) == spawnInputs.hBlindLoc,
-            "Incorrect H(b, r, c)"
-        );
+        // require(
+        //     SpawnCommitment.get(player) == spawnInputs.hBlindLoc,
+        //     "Incorrect H(b, r, c)"
+        // );
     }
 
     function spawnPlayer(address player, SpawnInputs memory sp) internal {

--- a/enclave/server.ts
+++ b/enclave/server.ts
@@ -261,6 +261,7 @@ async function sendSpawnSignature(
 
     // Check that location and tile can be spawned into
     if (!b.inBounds(loc.r, loc.c)) {
+        console.log("Submitted out of bounds");
         socket.disconnect();
         return;
     }

--- a/game/Board.ts
+++ b/game/Board.ts
@@ -134,7 +134,7 @@ export class Board {
             for (let c = 0; c < 25; c++) {
                 let tl = this.getTile({r, c}, 0n);
                 switch (tl.tileType) {
-                    case Tile.NORMAL_TILE:
+                    case Tile.BARE_TILE:
                         process.stdout.write("[_]");
                         break;
                     case Tile.WATER_TILE:
@@ -215,7 +215,7 @@ export class Board {
                         this.playerCities.delete(oldOwner);
                     }
                 } else {
-                    // Normal/water tile with a new owner
+                    // Bare/water tile with a new owner
                     const locString = Utils.stringifyLocation(tl.loc);
                     this.cityTiles.get(oldTile.cityId)?.delete(locString);
                     this.cityTiles.get(tl.cityId)?.add(locString);
@@ -234,7 +234,7 @@ export class Board {
                 this.playerCities.get(oldOwner)?.delete(tl.cityId);
                 this.playerCities.get(newOwner)?.add(tl.cityId);
             } else {
-                // Normal/water tile with a new owner
+                // Bare/water tile with a new owner
                 const locString = Utils.stringifyLocation(tl.loc);
                 this.cityTiles.get(oldTile.cityId)?.delete(locString);
                 this.cityTiles.get(tl.cityId)?.add(locString);

--- a/game/Board.ts
+++ b/game/Board.ts
@@ -9,12 +9,13 @@ dotenv.config({ path: "../.env" });
 export class Board {
     static MOVE_WASM: string = "../circuits/move/move.wasm";
     static MOVE_PROVKEY: string = "../circuits/move/move.zkey";
-    static PERIMETER: bigint[][] = [-1n, 0n, 1n].flatMap((x) =>
-        [-1n, 0n, 1n].map((y) => [x, y])
+    static PERIMETER: number[][] = [-1, 0, 1].flatMap((x) =>
+        [-1, 0, 1].map((y) => [x, y])
     );
-    static SNARK_FIELD_SIZE: bigint = BigInt(
+    static SNARK_FIELD_SIZE: number = Number(
         <string>process.env.SNARK_FIELD_SIZE
     );
+    static COORDINATE_MAX_VALUE: number = 2 ** 31;
 
     t: Map<string, Tile>;
 
@@ -31,11 +32,11 @@ export class Board {
     /*
      * Check if a location = (row, col) pair is within the bounds of the board.
      */
-    public inBounds(r: bigint, c: bigint): boolean {
+    public inBounds(r: number, c: number): boolean {
         return (
-            r < Board.SNARK_FIELD_SIZE &&
+            r <= Board.COORDINATE_MAX_VALUE &&
             r >= 0 &&
-            c < Board.SNARK_FIELD_SIZE &&
+            c <= Board.COORDINATE_MAX_VALUE &&
             c >= 0
         );
     }
@@ -51,8 +52,8 @@ export class Board {
      * Populates the board with mystery tiles in a 10x10 grid.
      */
     public seed() {
-        for (let r = 0n; r < 10n; r++) {
-            for (let c = 0n; c < 10n; c++) {
+        for (let r = 0; r < 10; r++) {
+            for (let c = 0; c < 10; c++) {
                 const loc: Location = { r, c };
                 const tile: Tile = Tile.mystery(loc);
                 this.t.set(Utils.stringifyLocation(loc), tile);
@@ -100,8 +101,8 @@ export class Board {
      * the perspective of the client.
      */
     public printView(): void {
-        for (let r = 0n; r < 5n; r++) {
-            for (let c = 0n; c < 5n; c++) {
+        for (let r = 0; r < 5; r++) {
+            for (let c = 0; c < 5; c++) {
                 let tl: Tile = this.getTile({ r, c }, 0n);
                 let color;
                 const reset = "\x1b[0m";
@@ -142,8 +143,8 @@ export class Board {
 
     public getNearbyLocations(l: Location): Location[] {
         let locs: Location[] = [];
-        for (let r = l.r - 1n; r <= l.r + 1n; r++) {
-            for (let c = l.c - 1n; c <= l.c + 1n; c++) {
+        for (let r = l.r - 1; r <= l.r + 1; r++) {
+            for (let c = l.c - 1; c <= l.c + 1; c++) {
                 if (this.inBounds(r, c)) {
                     locs.push({ r, c });
                 }

--- a/game/Board.ts
+++ b/game/Board.ts
@@ -130,8 +130,8 @@ export class Board {
     }
 
     public printTerrain(): void {
-        for (let r = 0; r < 50; r++) {
-            for (let c = 0; c < 50; c++) {
+        for (let r = 0; r < 25; r++) {
+            for (let c = 0; c < 25; c++) {
                 let tl = this.getTile({r, c}, 0n);
                 switch (tl.tileType) {
                     case Tile.NORMAL_TILE:

--- a/game/Board.ts
+++ b/game/Board.ts
@@ -4,6 +4,7 @@ import { Groth16Proof, Terrain, TerrainGenerator, Utils } from "./Utils.js";
 import { Player } from "./Player.js";
 import { Tile, Location } from "./Tile.js";
 import dotenv from "dotenv";
+import { TerrainUtils } from "./Terrain.js";
 dotenv.config({ path: "../.env" });
 
 export class Board {
@@ -18,12 +19,14 @@ export class Board {
     static COORDINATE_MAX_VALUE: number = 2 ** 31;
 
     t: Map<string, Tile>;
+    terrainUtils: TerrainUtils;
 
     playerCities: Map<string, Set<number>>;
     cityTiles: Map<number, Set<string>>;
 
-    public constructor() {
+    public constructor(terrainUtils: TerrainUtils) {
         this.t = new Map<string, Tile>();
+        this.terrainUtils = terrainUtils;
 
         this.playerCities = new Map<string, Set<number>>();
         this.cityTiles = new Map<number, Set<string>>();
@@ -126,6 +129,29 @@ export class Board {
         process.stdout.write("---\n");
     }
 
+    public printTerrain(): void {
+        for (let r = 0; r < 50; r++) {
+            for (let c = 0; c < 50; c++) {
+                let tl = this.getTile({r, c}, 0n);
+                switch (tl.tileType) {
+                    case Tile.NORMAL_TILE:
+                        process.stdout.write("[_]");
+                        break;
+                    case Tile.WATER_TILE:
+                        process.stdout.write("[~]");
+                        break;
+                    case Tile.HILL_TILE:
+                        process.stdout.write("[^]");
+                        break;
+                    default:
+                        break;
+                }
+            }
+            process.stdout.write("\n");
+        }
+        process.stdout.write("---\n");
+    }
+
     /*
      * Getter for Tile at a location, or undefined if passed in location is
      * invalid.
@@ -134,7 +160,7 @@ export class Board {
         if (this.assertBounds(l)) {
             let tl = this.t.get(Utils.stringifyLocation(l));
             if (!tl) {
-                tl = Tile.genVirtual(l, r);
+                tl = Tile.genVirtual(l, r, this.terrainUtils);
             }
             return tl;
         }

--- a/game/Player.ts
+++ b/game/Player.ts
@@ -30,18 +30,19 @@ export class Player {
     }
 
     public hBlindLoc(l: Location): string {
-        return Utils.poseidonExt([this.blind, l.r, l.c]).toString();
+        return Utils.poseidonExt([
+            this.blind,
+            BigInt(l.r),
+            BigInt(l.c),
+        ]).toString();
     }
 
-    public async commitToSpawn(spawnLoc: Location, nStates: any) {
+    public async commitHBlind(spawnLoc: Location, nStates: any) {
         const tx = await nStates.commitToSpawn(this.hBlindLoc(spawnLoc));
         await tx.wait();
     }
 
-    public async spawnZKP(
-        prevTile: Tile,
-        spawnTile: Tile
-    ) {
+    public async spawnZKP(prevTile: Tile, spawnTile: Tile) {
         const { proof, publicSignals } = await groth16.fullProve(
             {
                 canSpawn: prevTile.isSpawnable() ? "1" : "0",

--- a/game/Terrain.ts
+++ b/game/Terrain.ts
@@ -32,12 +32,10 @@ export class TerrainUtils {
                 }
         );
 
-        return perlinValue;
-
         let terrain: Terrain;
         if (perlinValue >= this.perlinThresholdHill) {
             terrain = Terrain.HILL;
-        } else if (perlinValue <= this.perlinThresholdWater) {
+        } else if (perlinValue >= this.perlinThresholdWater) {
             terrain = Terrain.WATER;
         } else {
             terrain = Terrain.BARE;

--- a/game/Terrain.ts
+++ b/game/Terrain.ts
@@ -1,21 +1,14 @@
-import { createPerlin } from "@latticexyz/noise";
+import { perlin } from "@darkforest_eth/hashing";
 import { Terrain } from "./Utils.js";
 import { Location } from "./Tile.js";
 
 export class TerrainUtils {
-    perlin: any;
     terrainMemo: Map<string, Terrain>;
-    perlinDenom = Number(process.env.PERLIN_DENOM);
-    perlinDigits = Number(process.env.PERLIN_DIGITS);
     perlinThresholdHill = Number(process.env.PERLIN_THRESHOLD_HILL);
     perlinThresholdWater = Number(process.env.PERLIN_THRESHOLD_WATER);
 
     constructor() {
         this.terrainMemo = new Map<string, Terrain>();
-    }
-
-    async setup() {
-        this.perlin = await createPerlin();
     }
 
     static getKey(loc: Location) {
@@ -28,10 +21,18 @@ export class TerrainUtils {
         if (cached !== undefined) {
             return cached;
         }
-        const perlinValue = Math.floor(
-            this.perlin(loc.r, loc.c, 0, this.perlinDenom) *
-                10 ** this.perlinDigits
+        const perlinValue = perlin(
+                { x: Number(loc.r), y: Number(loc.c) },
+                {
+                    key: 2,
+                    scale: 2,
+                    mirrorX: false,
+                    mirrorY: false,
+                    floor: true,
+                }
         );
+
+        return perlinValue;
 
         let terrain: Terrain;
         if (perlinValue >= this.perlinThresholdHill) {

--- a/game/Terrain.ts
+++ b/game/Terrain.ts
@@ -4,6 +4,8 @@ import { Location } from "./Tile.js";
 
 export class TerrainUtils {
     terrainMemo: Map<string, Terrain>;
+    perlinKey = Number(process.env.PERLIN_KEY);
+    perlinScale = Number(process.env.PERLIN_SCALE);
     perlinThresholdHill = Number(process.env.PERLIN_THRESHOLD_HILL);
     perlinThresholdWater = Number(process.env.PERLIN_THRESHOLD_WATER);
 
@@ -24,8 +26,8 @@ export class TerrainUtils {
         const perlinValue = perlin(
                 { x: Number(loc.r), y: Number(loc.c) },
                 {
-                    key: 2,
-                    scale: 2,
+                    key: this.perlinKey,
+                    scale: this.perlinScale,
                     mirrorX: false,
                     mirrorY: false,
                     floor: true,

--- a/game/Tile.ts
+++ b/game/Tile.ts
@@ -6,8 +6,8 @@ import { Player } from "./Player.js";
 import { Utils } from "./Utils.js";
 
 export type Location = {
-    r: bigint;
-    c: bigint;
+    r: number;
+    c: number;
 };
 
 export class Tile {
@@ -179,7 +179,7 @@ export class Tile {
     static fromJSON(obj: any): Tile {
         return new Tile(
             new Player(obj.symbol, obj.address),
-            { r: BigInt(obj.r), c: BigInt(obj.c) },
+            { r: Number(obj.r), c: Number(obj.c) },
             parseInt(obj.resources, 10),
             BigInt(obj.key),
             parseInt(obj.cityId, 10),
@@ -230,7 +230,7 @@ export class Tile {
      * random value.
      */
     static proceduralSalt(l: Location, r: bigint): bigint {
-        return Utils.poseidonExt([r, l.r, l.c]);
+        return Utils.poseidonExt([r, BigInt(l.r), BigInt(l.c)]);
     }
 
     /*

--- a/game/Tile.ts
+++ b/game/Tile.ts
@@ -22,7 +22,7 @@ export class Tile {
     static UNOWNED_ID: number = 0;
 
     // tileType options
-    static NORMAL_TILE: number = 0;
+    static BARE_TILE: number = 0;
     static CITY_TILE: number = 1;
     static WATER_TILE: number = 2;
     static HILL_TILE: number = 3;
@@ -194,7 +194,7 @@ export class Tile {
      * Meant to represent a tile in the fog of war.
      */
     static mystery(l: Location): Tile {
-        return new Tile(Tile.MYSTERY, l, 0, BigInt(0), 0, 0, this.NORMAL_TILE);
+        return new Tile(Tile.MYSTERY, l, 0, BigInt(0), 0, 0, this.BARE_TILE);
     }
 
     /*
@@ -250,7 +250,7 @@ export class Tile {
             case Terrain.HILL:
                 return this.HILL_TILE;
             default:
-                return this.NORMAL_TILE;
+                return this.BARE_TILE;
         }
     }
 

--- a/game/Tile.ts
+++ b/game/Tile.ts
@@ -1,9 +1,10 @@
 // @ts-ignore
 import { groth16 } from "snarkjs";
-import { Groth16Proof } from "./Utils.js";
+import { Groth16Proof, Terrain } from "./Utils.js";
 import { genRandomSalt } from "maci-crypto";
 import { Player } from "./Player.js";
 import { Utils } from "./Utils.js";
+import { TerrainUtils } from "./Terrain.js";
 
 export type Location = {
     r: number;
@@ -157,9 +158,10 @@ export class Tile {
     static async virtualZKP(
         loc: Location,
         rand: bigint,
-        hRand: bigint
+        hRand: bigint,
+        terrainUtils: TerrainUtils
     ): Promise<[Groth16Proof, any]> {
-        const v: Tile = Tile.genVirtual(loc, rand);
+        const v: Tile = Tile.genVirtual(loc, rand, terrainUtils);
         const { proof, publicSignals } = await groth16.fullProve(
             {
                 hRand: hRand.toString(),
@@ -213,7 +215,11 @@ export class Tile {
     /*
      * New virtual / unowned tile.
      */
-    static genVirtual(l: Location, r: bigint): Tile {
+    static genVirtual(
+        l: Location,
+        r: bigint,
+        terrainUtils: TerrainUtils
+    ): Tile {
         return new Tile(
             Tile.UNOWNED,
             l,
@@ -221,7 +227,7 @@ export class Tile {
             Tile.proceduralSalt(l, r),
             0,
             0,
-            this.NORMAL_TILE
+            Tile.terrainAt(l, terrainUtils)
         );
     }
 
@@ -231,6 +237,21 @@ export class Tile {
      */
     static proceduralSalt(l: Location, r: bigint): bigint {
         return Utils.poseidonExt([r, BigInt(l.r), BigInt(l.c)]);
+    }
+
+    /*
+     * Return type value corresponding to output of getTerrainAtLoc
+     */
+    static terrainAt(l: Location, terrainUtils: TerrainUtils): number {
+        const terrainValue = terrainUtils.getTerrainAtLoc(l);
+        switch (terrainValue) {
+            case Terrain.WATER:
+                return this.WATER_TILE;
+            case Terrain.HILL:
+                return this.HILL_TILE;
+            default:
+                return this.NORMAL_TILE;
+        }
     }
 
     /*

--- a/game/Utils.ts
+++ b/game/Utils.ts
@@ -35,9 +35,9 @@ export type TerrainGenerator = (location: Location) => Terrain;
 
 export const dummyTerrainGenerator = (location: Location) => {
     const { r: i, c: j } = location;
-    if (i === BigInt(0) && j === BigInt(1)) {
+    if (i === 0 && j === 1) {
         return Terrain.HILL;
-    } else if (i === BigInt(1) && j === BigInt(1)) {
+    } else if (i === 1 && j === 1) {
         return Terrain.WATER;
     } else {
         return Terrain.BARE;
@@ -63,8 +63,8 @@ export class Utils {
         try {
             const location = JSON.parse(locationString);
             return {
-                r: BigInt(location.r),
-                c: BigInt(location.c),
+                r: Number(location.r),
+                c: Number(location.c),
             };
         } catch (error) {
             console.error("Error while unstringifying location:", error);

--- a/game/package.json
+++ b/game/package.json
@@ -5,6 +5,7 @@
     "main": "index.ts",
     "license": "BSD-4-Clause",
     "dependencies": {
+        "@darkforest_eth/hashing": "^6.7.29",
         "@latticexyz/noise": "^2.0.0-next.12",
         "@types/circomlibjs": "^0.1.2",
         "circomlibjs": "^0.1.7",

--- a/game/yarn.lock
+++ b/game/yarn.lock
@@ -2,6 +2,25 @@
 # yarn lockfile v1
 
 
+"@darkforest_eth/hashing@^6.7.29":
+  version "6.7.29"
+  resolved "https://registry.yarnpkg.com/@darkforest_eth/hashing/-/hashing-6.7.29.tgz#61ec24956dab29cdf102fc7509293ab08f87b185"
+  integrity sha512-oiaAnFJif73/vWX0AK0w0hHL2PCZXwG9QSqphqQkJjKDIwAGvBLq8p/VsvlHvkQ3NCOlyHtuAd07zQDd7tP/wA==
+  dependencies:
+    "@darkforest_eth/types" "6.7.29"
+    big-integer "^1.6.48"
+
+"@darkforest_eth/types@6.7.29":
+  version "6.7.29"
+  resolved "https://registry.yarnpkg.com/@darkforest_eth/types/-/types-6.7.29.tgz#e97d0857ee8a1b134a28d9bf5e193872fd981dca"
+  integrity sha512-D8HT7fTeqsI4kzpbDiqs61mSCsH3LnAtC6uvzrfVkzclmQ+EHe7CtmXEbJGlT2Bi2jZ45aZIbghjavLd59z9Yw==
+  dependencies:
+    "@types/gl-matrix" "^3.2.0"
+    big-integer "^1.6.48"
+    ethers "^5.5.1"
+    gl-matrix "^3.3.0"
+    type-fest "^2.12.1"
+
 "@ethereumjs/common@2.5.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.5.0.tgz#ec61551b31bef7a69d1dc634d8932468866a4268"
@@ -478,6 +497,13 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/circomlibjs/-/circomlibjs-0.1.2.tgz#2d6021ea0680973f4b522dbb4f82401c81872f1f"
   integrity sha512-frsB+ZOIRA3I76hcoOIdkKO9kO+ZE9hNVT/Z27Cw6/gv6X3dGzWnSbRZkwCQ9NwGUzFtQugL4AfBBWKU3Uv0bg==
+
+"@types/gl-matrix@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/gl-matrix/-/gl-matrix-3.2.0.tgz#a62e0f26be4ab6fa55284a29eec631c8641438a1"
+  integrity sha512-CY4JAtSOGQX7rVgqVuOk7ZfaLv8VeadDMPj3smMOy8Hp/YiHONa3Mr0mEUgbo0eEwV7+Owpf6BwspcA7hv4NXg==
+  dependencies:
+    gl-matrix "*"
 
 "@types/http-cache-semantics@*":
   version "4.0.1"
@@ -1893,6 +1919,11 @@ getpass@^0.1.1:
   integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
   dependencies:
     assert-plus "^1.0.0"
+
+gl-matrix@*, gl-matrix@^3.3.0:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.3.tgz#fc1191e8320009fd4d20e9339595c6041ddc22c9"
+  integrity sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==
 
 glob-parent@~5.1.0:
   version "5.1.2"
@@ -3371,6 +3402,11 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^2.12.1:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Removed Lattice's perlin noise and integrated Darkforest's perlin noise circuits into the 'virtual' ZKP, so the virtual tile is constrained to have type corresponding to perlin noise at that location.

Other change: removed spawn commitments and hBlindLoc checks for the time being.

Tested with client CLI.