### PR TITLE
Troop bonuses

### DIFF
--- a/circuits/spawn/spawn.func.circom
+++ b/circuits/spawn/spawn.func.circom
@@ -35,8 +35,7 @@ template CheckTileHashes(N_TL_ATRS) {
     out <== AND()(hPrevTileCorrect, hSpawnTileCorrect);
 }
 
-template CheckCanSpawn(N_TL_ATRS, CITY_IDX, TYPE_IDX, CITY_TYPE, WATER_TYPE, 
-    HILL_TYPE) {
+template CheckCanSpawn(N_TL_ATRS, CITY_IDX, RSRC_IDX, TYPE_IDX, BARE_TYPE) {
     signal input canSpawn;
 
     signal input prevTile[N_TL_ATRS];
@@ -45,12 +44,16 @@ template CheckCanSpawn(N_TL_ATRS, CITY_IDX, TYPE_IDX, CITY_TYPE, WATER_TYPE,
 
     signal isUnowned <== IsEqual()([prevTile[CITY_IDX], 0]);
     signal isOwned <== NOT()(isUnowned);
-    signal isWater <== IsEqual()([prevTile[TYPE_IDX], WATER_TYPE]);
-    signal isHill <== IsEqual()([prevTile[TYPE_IDX], HILL_TYPE]);
-    signal isCity <== IsEqual()([prevTile[TYPE_IDX], CITY_TYPE]);
-    
-    signal circuitCanSpawn <== BatchIsZero(4)([isOwned, isWater, isHill, 
-        isCity]);
+
+    signal isBare <== IsEqual()([prevTile[TYPE_IDX], BARE_TYPE]);
+    signal isNotBare <== NOT()(isBare);
+
+    signal zeroTroops <== IsEqual()([prevTile[RSRC_IDX], 0]);
+    signal nonzeroTroops <== NOT()(zeroTroops);
+
+    signal circuitCanSpawn <== BatchIsZero(3)([isOwned, isNotBare, 
+        nonzeroTroops]);
+        
     out <== IsEqual()([circuitCanSpawn, canSpawn]);
 }
 
@@ -64,6 +67,7 @@ template Spawn() {
     var UPD_IDX = 5;
     var TYPE_IDX = 6;
 
+    var BARE_TYPE = 0;
     var CITY_TYPE = 1;
     var WATER_TYPE = 2;
     var HILL_TYPE = 3;
@@ -93,8 +97,8 @@ template Spawn() {
     tileHashesCorrect === 1;
 
     // Constrain canSpawn
-    signal canSpawnCorrect <== CheckCanSpawn(N_TL_ATRS, CITY_IDX, TYPE_IDX, 
-        CITY_TYPE, WATER_TYPE, HILL_TYPE)(canSpawn, prevTile);
+    signal canSpawnCorrect <== CheckCanSpawn(N_TL_ATRS, CITY_IDX, RSRC_IDX, 
+        TYPE_IDX, BARE_TYPE)(canSpawn, prevTile);
     canSpawnCorrect === 1;
 
     // hBlindLoc should be the hash of blind, row, col

--- a/game/Board.ts
+++ b/game/Board.ts
@@ -132,10 +132,14 @@ export class Board {
     public printTerrain(): void {
         for (let r = 0; r < 25; r++) {
             for (let c = 0; c < 25; c++) {
-                let tl = this.getTile({r, c}, 0n);
+                let tl = this.getTile({ r, c }, 0n);
                 switch (tl.tileType) {
                     case Tile.BARE_TILE:
-                        process.stdout.write("[_]");
+                        if (tl.resources === 5) {
+                            process.stdout.write("[5]");
+                        } else {
+                            process.stdout.write("[_]");
+                        }
                         break;
                     case Tile.WATER_TILE:
                         process.stdout.write("[~]");
@@ -312,7 +316,7 @@ export class Board {
             uTo = Tile.genOwned(
                 tFrom.owner,
                 tTo.loc,
-                nMobilize,
+                nMobilize + tTo.resources,
                 tFrom.cityId,
                 currentWaterInterval,
                 tTo.tileType
@@ -394,6 +398,31 @@ export class Board {
         const capturedTile = uTo.owner.address != tTo.owner.address;
         const takingCity = tTo.isCityCenter() && capturedTile ? "1" : "0";
 
+        console.log({
+            currentWaterInterval: currentWaterInterval.toString(),
+            fromCityId: tFrom.cityId.toString(),
+            toCityId: tTo.cityId.toString(),
+            ontoSelfOrUnowned,
+            numTroopsMoved: nMobilize.toString(),
+            enemyLoss: enemyLoss.toString(),
+            fromIsCityCenter: tFrom.isCityCenter() ? "1" : "0",
+            toIsCityCenter: tTo.isCityCenter() ? "1" : "0",
+            fromIsWaterTile: tFrom.isWater() ? "1" : "0",
+            toIsWaterTile: tTo.isWater() ? "1" : "0",
+            takingCity,
+            fromCityTroops: fromCityTroops.toString(),
+            toCityTroops: toCityTroops.toString(),
+            hTFrom: tFrom.hash(),
+            hTTo: tTo.hash(),
+            hUFrom: uFrom.hash(),
+            hUTo: uTo.hash(),
+            tFrom: tFrom.toCircuitInput(),
+            tTo: tTo.toCircuitInput(),
+            uFrom: uFrom.toCircuitInput(),
+            uTo: uTo.toCircuitInput(),
+            fromUpdatedTroops: fromUpdatedTroops.toString(),
+            toUpdatedTroops: toUpdatedTroops.toString(),
+        });
         const { proof, publicSignals } = await groth16.fullProve(
             {
                 currentWaterInterval: currentWaterInterval.toString(),

--- a/game/Terrain.ts
+++ b/game/Terrain.ts
@@ -6,6 +6,9 @@ export class TerrainUtils {
     terrainMemo: Map<string, Terrain>;
     perlinKey = Number(process.env.PERLIN_KEY);
     perlinScale = Number(process.env.PERLIN_SCALE);
+    perlinThresholdBonusTroops = Number(
+        process.env.PERLIN_THRESHOLD_BONUS_TROOPS
+    );
     perlinThresholdHill = Number(process.env.PERLIN_THRESHOLD_HILL);
     perlinThresholdWater = Number(process.env.PERLIN_THRESHOLD_WATER);
 
@@ -24,18 +27,20 @@ export class TerrainUtils {
             return cached;
         }
         const perlinValue = perlin(
-                { x: Number(loc.r), y: Number(loc.c) },
-                {
-                    key: this.perlinKey,
-                    scale: this.perlinScale,
-                    mirrorX: false,
-                    mirrorY: false,
-                    floor: true,
-                }
+            { x: Number(loc.r), y: Number(loc.c) },
+            {
+                key: this.perlinKey,
+                scale: this.perlinScale,
+                mirrorX: false,
+                mirrorY: false,
+                floor: true,
+            }
         );
 
         let terrain: Terrain;
-        if (perlinValue >= this.perlinThresholdHill) {
+        if (perlinValue >= this.perlinThresholdBonusTroops) {
+            terrain = Terrain.BONUS_TROOPS;
+        } else if (perlinValue >= this.perlinThresholdHill) {
             terrain = Terrain.HILL;
         } else if (perlinValue >= this.perlinThresholdWater) {
             terrain = Terrain.WATER;

--- a/game/Tile.ts
+++ b/game/Tile.ts
@@ -117,6 +117,13 @@ export class Tile {
     }
 
     /*
+     * Return true if this Tile is a bare tile.
+     */
+    isBare(): boolean {
+        return this.tileType === Tile.BARE_TILE;
+    }
+
+    /*
      * Return true if this Tile is a water tile.
      */
     isWater(): boolean {
@@ -141,12 +148,7 @@ export class Tile {
      * Return true if player should be allowed to spawn over this tile.
      */
     isSpawnable(): boolean {
-        return (
-            this.isUnowned() &&
-            !this.isWater() &&
-            !this.isHill() &&
-            !this.isCityCenter()
-        );
+        return this.isUnowned() && this.isBare() && this.resources === 0;
     }
 
     /*

--- a/game/Tile.ts
+++ b/game/Tile.ts
@@ -220,6 +220,30 @@ export class Tile {
         r: bigint,
         terrainUtils: TerrainUtils
     ): Tile {
+        let terrainValue = terrainUtils.getTerrainAtLoc(l);
+        let terrain;
+        switch (terrainValue) {
+            case Terrain.WATER:
+                terrain = Tile.WATER_TILE;
+                break;
+            case Terrain.HILL:
+                terrain = Tile.HILL_TILE;
+                break;
+            case Terrain.BONUS_TROOPS:
+                return new Tile(
+                    Tile.UNOWNED,
+                    l,
+                    5,
+                    Tile.proceduralSalt(l, r),
+                    0,
+                    0,
+                    Tile.BARE_TILE
+                );
+            default:
+                terrain = Tile.BARE_TILE;
+                break;
+        }
+
         return new Tile(
             Tile.UNOWNED,
             l,
@@ -227,7 +251,7 @@ export class Tile {
             Tile.proceduralSalt(l, r),
             0,
             0,
-            Tile.terrainAt(l, terrainUtils)
+            terrain
         );
     }
 

--- a/game/Utils.ts
+++ b/game/Utils.ts
@@ -29,6 +29,7 @@ export enum Terrain {
     BARE,
     WATER,
     HILL,
+    BONUS_TROOPS,
 }
 
 export type TerrainGenerator = (location: Location) => Terrain;


### PR DESCRIPTION
Some bare tiles have +5 troops on them. Moving onto these tiles gives you those 5 troops, as well as the tile itself. Constrained in circuit too.

Tested with client cli.